### PR TITLE
Stop discarding already accumulated batches on EOF

### DIFF
--- a/batch/batch.go
+++ b/batch/batch.go
@@ -248,10 +248,10 @@ func (b RecordSet) Batches() [][]byte {
 		}
 		r := bytes.NewReader(b)
 		if err := binary.Read(r, binary.BigEndian, &offset); err != nil {
-			return nil
+			break
 		}
 		if err := binary.Read(r, binary.BigEndian, &length); err != nil {
-			return nil
+			break
 		}
 		n := int(length + 8 + 4)
 		if len(b) < n {


### PR DESCRIPTION
This commit fixes error, when the next slice of batches is the last
and in this case binary.Read() will face with EOF error (or UnexpectedEOF
which doesn't much matter here). In this case we should keep
all batches we got and send them to appropriate consumers.