### PR TITLE
Reduce allocs in record.Marshal function

### DIFF
--- a/record/record_test.go
+++ b/record/record_test.go
@@ -2,6 +2,8 @@ package record
 
 import (
 	"encoding/base64"
+	"fmt"
+	"math/rand"
 	"testing"
 )
 
@@ -38,5 +40,25 @@ func TestUnitUnmarshal(t *testing.T) {
 	t.Logf("%+v", r)
 	if string(r.Value) != "m3" {
 		t.Fatal(string(r.Value))
+	}
+}
+
+func BenchmarkRecord_Marshal(b *testing.B) {
+	const messagesN = 1e3
+	msgs := make([]*Record, messagesN)
+	for i := 0; i < messagesN; i++ {
+		key := fmt.Sprintf("key_%d", i)
+		val := fmt.Sprintf("value_%d", i)
+		r := New([]byte(key), []byte(val))
+		r.Attributes = int8(i)
+		r.TimestampDelta = rand.Int63()
+		r.OffsetDelta = rand.Int63()
+		msgs[i] = r
+	}
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		b := msgs[i%messagesN].Marshal()
+		b = b[:]
 	}
 }

--- a/varint/varint_test.go
+++ b/varint/varint_test.go
@@ -1,6 +1,7 @@
 package varint
 
 import (
+	"encoding/binary"
 	"math"
 	"testing"
 )
@@ -8,7 +9,9 @@ import (
 func TestZigZag64(t *testing.T) {
 	tests := []int64{0, 1, -1, math.MaxInt32, math.MinInt32, math.MaxInt64, math.MinInt64}
 	for _, tt := range tests {
-		b := EncodeZigZag64(tt)
+		buf := make([]byte, binary.MaxVarintLen64)
+		var b []byte
+		b = PutZigZag64(b, buf, tt)
 		i, _ := DecodeZigZag64(b)
 		if i != tt {
 			t.Fatal(tt, i)


### PR DESCRIPTION
The purpose of the change is to redue allocs in the hot path
by reusing buffer for varint encoding.
`EncodeZigZag64` was replaced with `PutZigZag64` extending the API
of the function so it could accept pre-allocated buffers.

The benchmark results are following:
```
benchstat  old.txt new.txt
name              old time/op    new time/op    delta
Record_Marshal-8     395ns ± 2%     268ns ±11%  -32.07%  (p=0.008 n=5+5)

name              old alloc/op   new alloc/op   delta
Record_Marshal-8      288B ± 0%      176B ± 0%  -38.89%  (p=0.008 n=5+5)

name              old allocs/op  new allocs/op  delta
Record_Marshal-8      13.0 ± 0%       6.0 ± 0%  -53.85%  (p=0.008 n=5+5)
```