### PR TITLE
Add CommitOffsets method to commit multiple partitions at once

### DIFF
--- a/api/OffsetCommit/request.go
+++ b/api/OffsetCommit/request.go
@@ -4,15 +4,23 @@ import (
 	"github.com/mkocikowski/libkafka/api"
 )
 
-func NewRequest(group, topic string, partition int32, offset, retentionMs int64) *api.Request {
-	p := Partition{
-		PartitionIndex:   partition,
-		CommitedOffset:   offset,
-		CommitedMetadata: "",
+// NewRequest constructs api.Request with ApiKey OffsetCommit. Method supports
+// multiply offsets to be commited at once by providing them in offsets variable
+// which is a map partition -> offset.
+func NewRequest(group, topic string, offsets map[int32]int64, retentionMs int64) *api.Request {
+	offsetsMap := make([]Partition, len(offsets))
+	i := 0
+	for p, o := range offsets {
+		offsetsMap[i] = Partition{
+			PartitionIndex:   p,
+			CommitedOffset:   o,
+			CommitedMetadata: "",
+		}
+		i++
 	}
 	t := Topic{
 		Name:       topic,
-		Partitions: []Partition{p},
+		Partitions: offsetsMap,
 	}
 	return &api.Request{
 		ApiKey:     api.OffsetCommit,

--- a/client/group_test.go
+++ b/client/group_test.go
@@ -122,7 +122,7 @@ func TestIntegrationGroupOffsets(t *testing.T) {
 		t.Fatal(err)
 	}
 	//
-	if _, err = CallCreateTopic(bootstrap, topic, 1, 1); err != nil {
+	if _, err = CallCreateTopic(bootstrap, topic, 2, 1); err != nil {
 		t.Fatal(err)
 	}
 	// get offset for existing topic but where no offset has been committed
@@ -143,6 +143,42 @@ func TestIntegrationGroupOffsets(t *testing.T) {
 		t.Fatal(err)
 	}
 	if offset != 1 {
+		t.Fatal(offset)
+	}
+	// CommitOffsets
+	offsets := map[int32]int64{
+		0: 10,
+	}
+	if err = c.CommitOffsets(topic, offsets, 1000); err != nil {
+		t.Fatal(err)
+	}
+	offset, err = c.FetchOffset(topic, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if offset != 10 {
+		t.Fatal(offset)
+	}
+	// CommitOffsets with two partitions
+	offsets = map[int32]int64{
+		0: 100,
+		1: 200,
+	}
+	if err = c.CommitOffsets(topic, offsets, 1000); err != nil {
+		t.Fatal(err)
+	}
+	offset, err = c.FetchOffset(topic, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if offset != 100 {
+		t.Fatal(offset)
+	}
+	offset, err = c.FetchOffset(topic, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if offset != 200 {
 		t.Fatal(offset)
 	}
 }


### PR DESCRIPTION
This commit adds a new method to GroupClient: CommitOffsets()

The main purpose of the method is to do a bulk commit of the offsets
by providing a map partition -> offset.

The current way when committing happening for the only partition is left
without any changes due to backward compatibility.

Because of sending more than one partition in a single request, response
from the Kafka will be changed - for those requests, it will respond
with a list of partitions which were used in the CommitOffset request.

**UPD**: description was updated to reflect the main idea of the change