### PR TITLE
Connection timeouts

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -7,7 +7,7 @@ type Error struct {
 	Message string
 }
 
-func (e *Error) Error() string {
+func (e Error) Error() string {
 	s := fmt.Sprintf("error code %d (%s)", e.Code, errorDescriptions[int(e.Code)])
 	if e.Message != "" {
 		s += ": " + e.Message


### PR DESCRIPTION
The motivation behind the change is to provide ability to protect
client calls from being stuck while communicating with
slow or unresponsive Kafka servers.
Read/Write timeouts aren't set by default to be consistent with other param values in PartitionClient.

cc @twalwyn