### PR TITLE
Connection timeouts

### DIFF
--- a/client/group.go
+++ b/client/group.go
@@ -96,7 +96,7 @@ func (c *GroupClient) Call(req *api.Request, respStructPtr interface{}) error {
 	if err := c.connect(); err != nil {
 		return err
 	}
-	err := call(c.conn, req, respStructPtr)
+	err := callWithTimeout(c.conn, req, respStructPtr, libkafka.ConnTimeout)
 	if err != nil {
 		c.disconnect()
 	}

--- a/client/partition.go
+++ b/client/partition.go
@@ -151,7 +151,7 @@ func (c *PartitionClient) call(req *api.Request, v interface{}) error {
 	if req.ApiKey == api.Produce && c.versions.ApiKeys[api.Produce].MaxVersion == 5 {
 		req.ApiVersion = 5 // downgrade to be able to produce to kafka 1.0
 	}
-	err := call(c.conn, req, v)
+	err := callWithTimeout(c.conn, req, v, libkafka.ConnTimeout)
 	if err != nil {
 		c.disconnect()
 	}

--- a/client/partition_test.go
+++ b/client/partition_test.go
@@ -4,10 +4,13 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
+	"net"
 	"testing"
 	"time"
 
+	"github.com/mkocikowski/libkafka"
 	"github.com/mkocikowski/libkafka/api/Metadata"
+	"github.com/mkocikowski/libkafka/api/Produce"
 )
 
 func init() {
@@ -108,5 +111,55 @@ func TestUnitLeaderString(t *testing.T) {
 	s := fmt.Sprintf("%v", b)
 	if s != "foo:1:bar:9092" {
 		t.Fatal(s)
+	}
+}
+
+func TestPartitionClient_CallTimeout(t *testing.T) {
+	// start listener on random port
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to start listener: %s", err)
+	}
+	defer ln.Close()
+	go func() {
+		// accept the connection but don't read from it
+		if _, err = ln.Accept(); err != nil {
+			t.Fatalf("failed to accept conn: %s", err)
+		}
+	}()
+
+	// establish connection to the listener
+	conn, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatalf("failed to dial conn: %s", err)
+	}
+	c := &PartitionClient{conn: conn}
+
+	oldTimeout := libkafka.ConnTimeout
+	defer func() {
+		libkafka.ConnTimeout = oldTimeout
+	}()
+	libkafka.ConnTimeout = 100 * time.Millisecond
+
+	resultCh := make(chan error)
+	defer close(resultCh)
+	// issue an API call via established connection
+	go func() {
+		req := Produce.NewRequest(&Produce.Args{}, nil)
+		req.ApiKey = 1
+		resultCh <- c.call(req, &Produce.Response{})
+	}()
+
+	timeout := time.After(2 * libkafka.ConnTimeout)
+	select {
+	case <-timeout:
+		t.Fatal("test timed out")
+	case err := <-resultCh:
+		if err == nil {
+			t.Fatalf("expected to have timeout err; got nil instead")
+		}
+		if nerr, ok := err.(net.Error); ok && nerr.Timeout() {
+			t.Fatalf("expected to have timeout error; got %q instead", err)
+		}
 	}
 }

--- a/errors.go
+++ b/errors.go
@@ -7,7 +7,7 @@ type Error struct {
 	Message string
 }
 
-func (e *Error) Error() string {
+func (e Error) Error() string {
 	s := fmt.Sprintf("error code %d (%s)", e.Code, errorDescriptions[int(e.Code)])
 	if e.Message != "" {
 		s += ": " + e.Message

--- a/libkafka.go
+++ b/libkafka.go
@@ -65,8 +65,13 @@ type Batch = batch.Batch
 type Compressor = batch.Compressor
 type Decompressor = batch.Decompressor
 
-// DialTimeout value is used in net.DialTimeout calls to connect to kafka
-// brokers (partition leaders, group coordinators, bootstrap hosts). Changing
-// it is not safe for concurrent use. If you want to change it, do it once,
-// right at the beginning.
-var DialTimeout = 5 * time.Second
+// Changing timeouts is not safe for concurrent use. If you want to change it,
+// do it once, right at the beginning.
+var (
+	// DialTimeout value is used in net.DialTimeout calls to connect to kafka
+	// brokers (partition leaders, group coordinators, bootstrap hosts).
+	DialTimeout = 5 * time.Second
+	// ConnTimeout used for setting deadlines while communicating via TCP.
+	// Set it to zero to prevent setting connection deadlines.
+	ConnTimeout = 60 * time.Second
+)


### PR DESCRIPTION
The motivation behind the change is to provide ability to protect
client calls from being stuck while communicating with
slow or unresponsive Kafka servers.
The timeout setting is global and set to meaningful default value of
1min. Clients should be able to update the value if they need to.