### PR TITLE
clean up names, build on top of Roman's "timeout" commit

### DIFF
--- a/client/fetcher/fetcher.go
+++ b/client/fetcher/fetcher.go
@@ -56,8 +56,10 @@ type PartitionFetcher struct {
 	client.PartitionClient
 	offset int64
 	//
-	MinBytes      int32
-	MaxBytes      int32
+	MinBytes int32
+	MaxBytes int32
+	// MaxWaitTimeMs defines an alternative threshold to Max/MinBytes. Keep
+	// it < libkafka.RequestTimeout.
 	MaxWaitTimeMs int32
 }
 

--- a/client/group.go
+++ b/client/group.go
@@ -19,7 +19,7 @@ import (
 func CallFindCoordinator(bootstrap, groupId string) (*FindCoordinator.Response, error) {
 	req := FindCoordinator.NewRequest(groupId)
 	resp := &FindCoordinator.Response{}
-	return resp, connectAndCall(bootstrap, req, resp)
+	return resp, connectToRandomBrokerAndCall(bootstrap, req, resp)
 }
 
 func GetGroupCoordinator(bootstrap, groupId string) (string, error) {
@@ -96,7 +96,7 @@ func (c *GroupClient) Call(req *api.Request, respStructPtr interface{}) error {
 	if err := c.connect(); err != nil {
 		return err
 	}
-	err := callWithTimeout(c.conn, req, respStructPtr, libkafka.ConnTimeout)
+	err := call(c.conn, req, respStructPtr)
 	if err != nil {
 		c.disconnect()
 	}

--- a/client/partition.go
+++ b/client/partition.go
@@ -151,7 +151,7 @@ func (c *PartitionClient) call(req *api.Request, v interface{}) error {
 	if req.ApiKey == api.Produce && c.versions.ApiKeys[api.Produce].MaxVersion == 5 {
 		req.ApiVersion = 5 // downgrade to be able to produce to kafka 1.0
 	}
-	err := callWithTimeout(c.conn, req, v, libkafka.ConnTimeout)
+	err := call(c.conn, req, v)
 	if err != nil {
 		c.disconnect()
 	}

--- a/client/partition_test.go
+++ b/client/partition_test.go
@@ -4,13 +4,10 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
-	"net"
 	"testing"
 	"time"
 
-	"github.com/mkocikowski/libkafka"
 	"github.com/mkocikowski/libkafka/api/Metadata"
-	"github.com/mkocikowski/libkafka/api/Produce"
 )
 
 func init() {
@@ -67,7 +64,7 @@ func TestIntergationPartitionClientTopicDoesNotExist(t *testing.T) {
 
 // the purpose of this test is to test that when ConnMaxIdle is set connection
 // is automatically closed and reopened when the idle time is exceeded
-func TestIntergationPartitionClientConnectionTimeout(t *testing.T) {
+func TestIntergationPartitionClientConnectionIdleTimeout(t *testing.T) {
 	bootstrap := "localhost:9092"
 	topic := fmt.Sprintf("test-%x", rand.Uint32())
 	if _, err := CallCreateTopic(bootstrap, topic, 1, 1); err != nil {
@@ -111,55 +108,5 @@ func TestUnitLeaderString(t *testing.T) {
 	s := fmt.Sprintf("%v", b)
 	if s != "foo:1:bar:9092" {
 		t.Fatal(s)
-	}
-}
-
-func TestPartitionClient_CallTimeout(t *testing.T) {
-	// start listener on random port
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("failed to start listener: %s", err)
-	}
-	defer ln.Close()
-	go func() {
-		// accept the connection but don't read from it
-		if _, err = ln.Accept(); err != nil {
-			t.Fatalf("failed to accept conn: %s", err)
-		}
-	}()
-
-	// establish connection to the listener
-	conn, err := net.Dial("tcp", ln.Addr().String())
-	if err != nil {
-		t.Fatalf("failed to dial conn: %s", err)
-	}
-	c := &PartitionClient{conn: conn}
-
-	oldTimeout := libkafka.ConnTimeout
-	defer func() {
-		libkafka.ConnTimeout = oldTimeout
-	}()
-	libkafka.ConnTimeout = 100 * time.Millisecond
-
-	resultCh := make(chan error)
-	defer close(resultCh)
-	// issue an API call via established connection
-	go func() {
-		req := Produce.NewRequest(&Produce.Args{}, nil)
-		req.ApiKey = 1
-		resultCh <- c.call(req, &Produce.Response{})
-	}()
-
-	timeout := time.After(2 * libkafka.ConnTimeout)
-	select {
-	case <-timeout:
-		t.Fatal("test timed out")
-	case err := <-resultCh:
-		if err == nil {
-			t.Fatalf("expected to have timeout err; got nil instead")
-		}
-		if nerr, ok := err.(net.Error); ok && nerr.Timeout() {
-			t.Fatalf("expected to have timeout error; got %q instead", err)
-		}
 	}
 }

--- a/libkafka.go
+++ b/libkafka.go
@@ -65,13 +65,17 @@ type Batch = batch.Batch
 type Compressor = batch.Compressor
 type Decompressor = batch.Decompressor
 
-// Changing timeouts is not safe for concurrent use. If you want to change it,
-// do it once, right at the beginning.
+// Changing timeouts is not safe for concurrent use. If you want to change
+// them, do it once, right at the beginning.
 var (
-	// DialTimeout value is used in net.DialTimeout calls to connect to kafka
-	// brokers (partition leaders, group coordinators, bootstrap hosts).
+	// DialTimeout value is used in net.DialTimeout calls to connect to
+	// kafka brokers (partition leaders, group coordinators, bootstrap
+	// hosts).
 	DialTimeout = 5 * time.Second
-	// ConnTimeout used for setting deadlines while communicating via TCP.
-	// Set it to zero to prevent setting connection deadlines.
-	ConnTimeout = 60 * time.Second
+	// RequestTimeout used for setting deadlines while communicating via
+	// TCP. Any single api call (request-response) can not take longer than
+	// RequestTimeout. Set it to zero to prevent setting connection
+	// deadlines. MaxWaitTimeMs for fetch requests should not be greater
+	// than RequestTimeout.
+	RequestTimeout = 60 * time.Second
 )

--- a/record/record_test.go
+++ b/record/record_test.go
@@ -43,7 +43,7 @@ func TestUnitMarshal(t *testing.T) {
 			t.Fatal(b, b4)
 		}
 		//
-		t.Logf("%v %s", b, base64.StdEncoding.EncodeToString(b))
+		//t.Logf("%v %s", b, base64.StdEncoding.EncodeToString(b))
 		r, _ := Unmarshal(b)
 		if !bytes.Equal(r.Key, test.key) {
 			t.Fatal(r.Key, test.key)


### PR DESCRIPTION
Remove redundant callWithTimeout, as all calls use timeout. Change
ConnTimeout to RequestTimeout as I feel it better describes how / where
the timeout is applied. Clean up some internal function names as they
were not obvious to me reading code for the first time in a while.