### PR TITLE
Mik/ttl

### DIFF
--- a/client/fetcher/fetcher.go
+++ b/client/fetcher/fetcher.go
@@ -55,11 +55,15 @@ type PartitionFetcher struct {
 	sync.Mutex
 	client.PartitionClient
 	offset int64
-	//
+	// The minimum amount of data the server should return for a fetch
+	// request. If insufficient data is available the request will wait for
+	// that much data to accumulate before answering the request (up to
+	// limit set by MaxWaitTimeMs).
 	MinBytes int32
 	MaxBytes int32
-	// MaxWaitTimeMs defines an alternative threshold to Max/MinBytes. Keep
-	// it < libkafka.RequestTimeout.
+	// The maximum amount of time the server will block before answering
+	// the fetch request if there isn't sufficient data to immediately
+	// satisfy the requirement given by MinBytes. Keep it < libkafka.RequestTimeout.
 	MaxWaitTimeMs int32
 }
 

--- a/libkafka.go
+++ b/libkafka.go
@@ -78,4 +78,9 @@ var (
 	// deadlines. MaxWaitTimeMs for fetch requests should not be greater
 	// than RequestTimeout.
 	RequestTimeout = 60 * time.Second
+	// ConnectionTTL specifies the max time a connection will stay open
+	// (more accurately: connection will be closed on first request after
+	// the ttl). The TTL counts from the time connection was opened, not
+	// when it was last used.
+	ConnectionTTL time.Duration = 0
 )

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -13,7 +13,7 @@ ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
 RUN mkdir -p /opt
 
 #RUN wget -q -O - https://archive.apache.org/dist/kafka/1.0.0/kafka_2.12-1.0.0.tgz | tar -zxf - -C /opt
-RUN wget -q -O - http://mirrors.advancedhosters.com/apache/kafka/2.3.0/kafka_2.12-2.3.0.tgz | tar -zxf - -C /opt
+RUN wget -q -O - https://archive.apache.org/dist/kafka/2.3.0/kafka_2.12-2.3.0.tgz | tar -zxf - -C /opt
 
 #RUN mv /opt/kafka_2.12-1.0.0 /opt/kafka
 RUN mv /opt/kafka_2.12-2.3.0 /opt/kafka


### PR DESCRIPTION
global ConnectionTTL for cycling long lived connections. 

i considered making it a field on client.PratitionClient, but then all higher-level libraries would have to be changed as well. `RequestTimeout` and `DialTimeout` are already globals, so there is some "precedent".

set `libkafka.ConnectionTTL` to have connections closed and re-opened on the next call after the ttl. This is intended for cycling long lived connections. Default value of 0 means no ttl.