### PR TITLE
add logic to forget cached resolved srv record on call failure

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -73,3 +73,14 @@ func TestIntegrationCallCreateTopicRequestTimeout(t *testing.T) {
 	}
 	t.Fatalf("expected timeout got %v", err)
 }
+
+func TestUnitConnectToRandomBrokerAndCallErrorForgetSRV(t *testing.T) {
+	srvLookupCache["foo"] = []string{"bar:1"}
+	err := connectToRandomBrokerAndCall("foo", nil, nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if _, ok := srvLookupCache["foo"]; ok {
+		t.Fatal("expected key to be deleted because of call error")
+	}
+}


### PR DESCRIPTION
client caches srv record resolutions. Add logic to clear that cache when
a call to one of the brokers fails (likely brokers were deleted /
moved). This is not a "fatal" flaw but results in needless retries.

Change client.LookupSrv and client.RandomBroker to lookupSrv and
randomBroker (there is no need for them to be public).