### PR TITLE
add recover() to PartitionClient.disconnect

### DIFF
--- a/client/partition.go
+++ b/client/partition.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"log"
 	"net"
 	"sync"
 	"time"
@@ -131,6 +132,11 @@ func (c *PartitionClient) disconnect() error {
 	if c.conn == nil {
 		return nil
 	}
+	defer func() {
+		if r := recover(); r != nil {
+			log.Printf("recovered in PartitionClient.disconnect: %v", r)
+		}
+	}()
 	c.conn.Close()
 	c.conn = nil
 	return nil


### PR DESCRIPTION
there have been some panics when using go boring. Not sure what that is
all about, but recover should prevent catastrophic failures of
applications.