### PR TITLE
Avoid storing "typed" nil in PartitionClient.conn

### DIFF
--- a/client/partition.go
+++ b/client/partition.go
@@ -100,16 +100,18 @@ func (c *PartitionClient) connect() (err error) {
 		return fmt.Errorf("error getting partition leader: %w", err)
 	}
 	if c.TLS != nil {
-		c.conn, err = tls.DialWithDialer(&net.Dialer{Timeout: libkafka.DialTimeout}, "tcp", c.leader.Addr(), c.TLS)
+		conn, err := tls.DialWithDialer(&net.Dialer{Timeout: libkafka.DialTimeout}, "tcp", c.leader.Addr(), c.TLS)
 		if err != nil {
 			return err
 		}
+		c.conn = conn
 	}
 	if c.TLS == nil {
-		c.conn, err = net.DialTimeout("tcp", c.leader.Addr(), libkafka.DialTimeout)
+		conn, err := net.DialTimeout("tcp", c.leader.Addr(), libkafka.DialTimeout)
 		if err != nil {
 			return err
 		}
+		c.conn = conn
 	}
 	c.connOpened = time.Now().UTC()
 	c.connLastUsed = c.connOpened


### PR DESCRIPTION
We are experiencing an issue in production due to a bunch of unfortunate
things that are each fine individually, but all together they work
badly. It manifests itself in a panic in the PartitionClient code that
handles connecting/reconnecting to kafka.

We only started getting the panics once we enabled TLS. Here is a
backtrace:

    goroutine 225 [running]:
    crypto/tls.(*Conn).Close(0x0, 0xc23eca45f0, 0xbe1f20)
            /usr/local/go/src/crypto/tls/conn.go:1310 +0x26
    github.com/mkocikowski/libkafka/client.(*PartitionClient).disconnect(...)
            /repo/vendor/github.com/mkocikowski/libkafka/client/partition.go:130
    github.com/mkocikowski/libkafka/client.(*PartitionClient).Close(0xc0001aed10, 0x0, 0x0)
            /repo/vendor/github.com/mkocikowski/libkafka/client/partition.go:141 +0x9c
    github.com/mkocikowski/kafkaclient/producer.(*Async).produce(0xc0001ae6e0, 0xc1fa5e8a00)
            /repo/vendor/github.com/mkocikowski/kafkaclient/producer/producer.go:189 +0x2ce
    github.com/mkocikowski/kafkaclient/producer.(*Async).run(0xc0001ae6e0)
            /repo/vendor/github.com/mkocikowski/kafkaclient/producer/producer.go:225 +0x15f
    github.com/mkocikowski/kafkaclient/producer.(*Async).Start.func1(0xc0001ae6e0)
            /repo/vendor/github.com/mkocikowski/kafkaclient/producer/producer.go:264 +0x2b
    created by github.com/mkocikowski/kafkaclient/producer.(*Async).Start
            /repo/vendor/github.com/mkocikowski/kafkaclient/producer/producer.go:263 +0x2ea

The Close() method is being called with a nil receiver, which is only
possible if something set it to nil before the call. The only place
where we set it is in client/partition.go:

    if c.TLS != nil {
        c.conn, err = tls.DialWithDialer(&net.Dialer{Timeout: libkafka.DialTimeout}, "tcp", c.leader.Addr(), c.TLS)
        if err != nil {
            return err
        }
    }
    if c.TLS == nil {
        c.conn, err = net.DialTimeout("tcp", c.leader.Addr(), libkafka.DialTimeout)
        if err != nil {
            return err
        }
    }

If you look at the signatures of tls.DialWithDialer and net.DialTimeout,
you can see that tls.DialWithDialer returns a struct pointer
(*tls.Conn), while net.DialTimeout returns an interface value
(net.Conn).

It is all fine, until we get to saving the returned value into c.conn
and then comparing that to nil later in (*PartitionClient).disconnect():

    func (c *PartitionClient) disconnect() error {
        // no mutex here. disconnect() is called only from call() and from
        // Close(), and that is where the mutex is acquired.
        if c.conn == nil {
            return nil
        }
        defer func() {
            if r := recover(); r != nil {
                log.Printf("recovered in PartitionClient.disconnect: %v", r)
            }
        }()
        c.conn.Close()
        c.conn = nil
        return nil
    }

We check whether c.conn is nil before calling c.conn.Close(). This is
where the Go equality logic for interface values kicks in. The language
spec says:

    > Interface values are comparable. Two interface values are equal if
    > they have identical dynamic types and equal dynamic values or if
    > both have value nil.

So, an interface value is a tuple (dynamic_type, dynamic_value), and
when we write `if c.conn == nil {` what Go actually does is it compares
(*tls.Conn, nil) to (nil, nil). This results in `false` even though
both dynamic values are nil, because the dynamic types are different.

It has been working fine before we switched to TLS, because
net.DialTimeout() returns an interface type, not concrete one. This
means when it fails it returns an "untyped" nil, as in (nil, nil). Then
we compare (nil, nil) to (nil, nil) and get a `true`.

Here is a [Go playground](https://play.golang.org/p/iJ2XwnPkZdM) that
demonstrates the difference.

On top of all of the above, another quirk of Go is that it allows
calling methods with nil receiver. It is perfectly legal and you can
even have meaningful behavior there if you want. Because the variable
c.conn is of interface type, when you call c.conn.Close() Go
extracts the dynamic type information from the tuple (*tls.Conn, nil)
and calls the proper function with nil as the receiver. See [this
playground](https://play.golang.org/p/_JYJFtmSzYn) for demo. The
implementation of (*tls.Conn).Close() does not check for nil receiver,
so it panics when tries to dereference it.

BTW, if you look at the implementation of (*net.conn).Close() you will
see that it checks for nil receiver. It is ironic, that non-TLS code
wouldn't panic even if we didn't do any checks before calling Close(),
but the TLS code panics even with the checks for nil in place. All
because sometimes "nil is not nil" (this is google-able).

Fix this by not assigning c.conn at all if dialling fails, it remains
a (nil, nil) interface value.

Extra
-----

Constantin Pan:
> We were discussing this issue during the standup. We figured it must
> be a nil receiver when Close() is called, because during the call
> nothing can change it externally, it is a local variable. Then I looked
> at the only place where c.conn is set, it is the call to
> tls.DialWhatever(), I saw the function's return type, the variable we
> save it to, and then the check for nil, and it clicked.

Mik Kocikowski:
> when you make the libkafka fix please add this explanation ^^ for
> educational value