### PR TITLE
Return error if provided SRV record can't be resolved

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -9,6 +9,7 @@ package client
 import (
 	"bufio"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"math/rand"
 	"net"
@@ -26,6 +27,8 @@ import (
 var (
 	srvLookupMutex sync.Mutex
 	srvLookupCache = make(map[string][]string) // TODO: ttl
+
+	errNotAnSRV = fmt.Errorf("not an SRV")
 )
 
 func lookupSrv(name string) ([]string, error) {
@@ -38,19 +41,20 @@ func lookupSrv(name string) ([]string, error) {
 	}
 	_, srvs, err := net.LookupSRV("", "", name)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w: %s", errNotAnSRV, err)
 	}
 	var addrs []string
 	for _, srv := range srvs {
 		hosts, err := net.LookupHost(srv.Target)
-		if err != nil {
-			return nil, err
-		}
-		if len(hosts) == 0 {
-			return nil, fmt.Errorf("unknown error looking up host %v for srv record %v", srv.Target, name)
+		// skip hosts that can't be resolved
+		if err != nil || len(hosts) == 0 {
+			continue
 		}
 		host := net.JoinHostPort(hosts[0], strconv.Itoa(int(srv.Port)))
 		addrs = append(addrs, host)
+	}
+	if len(addrs) < 1 {
+		return nil, fmt.Errorf("failed to resolve SRV record %q: no hosts found", name)
 	}
 	srvLookupCache[name] = addrs
 	addrsCopy := make([]string, len(addrs))
@@ -64,17 +68,20 @@ func forgetSrv(name string) {
 	srvLookupMutex.Unlock()
 }
 
-// randomBroker tries to resolve name through a call to lookupSrv. If
-// successful it returns a random host:port from the list. If lookupSrv fails
-// it returns name unmodified (so you can pass "localhost:9092" for example).
+// randomBroker tries to resolve name through a call to lookupSrv. If successful
+// it returns a random host:port from the list. lookupSrv in its turn invokes
+// net.LookupSRV(), unsuccessful result is considered as not an SRV record, so
+// you can pass "localhost:9092" for example. It panics, if resolved SRV record
+// has no hosts.
 func randomBroker(name string) string {
 	addrs, err := lookupSrv(name)
 	if err != nil {
-		return name
+		if errors.Is(err, errNotAnSRV) {
+			return name
+		}
+		panic(err)
 	}
-	if len(addrs) == 0 { // is this possible?
-		return name
-	}
+
 	rand.Shuffle(len(addrs), func(i, j int) {
 		addrs[i], addrs[j] = addrs[j], addrs[i]
 	})


### PR DESCRIPTION
Replace panicing in randomBroker() with returning an error
    
    This func is used internally in the only place: connectToRandomBroker(),
    which already returns error so we can replace panic() safely.

Add panic to randomBroker() if provided SRV record can't be resolved

    `randomBroker()` accepts a name to be resolved for further client
    calls. It could be a single broker name or an SRV record. If it's
    an SRV record that for some reason resolves into an empty list of
    hosts, `randomBroker()` will panic.
    If the provided name is not an SRV, it will be used as is.

